### PR TITLE
Updated dependency versions to fix deprecation messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,8 @@ function start(options) {
 	options = options || {};
 	port = options.port || process.env['COLLECTOR_PORT'] || 3001;
 	var app = connect();
-	app.use(bodyParser({
-		limit: '50mb'
+	app.use(bodyParser.json({
+		limit: '50mb' 
 	}));
 	app.use(function serveCoverageHandle(req, res, next) {
 		if (req.url.substr(1) === 'data' && req.method.toLowerCase() === 'get') {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "url": "https://github.com/r3b/coverage-collector/issues"
   },
   "dependencies": {
-    "connect": "~2.14.4",
-    "body-parser": "~1.0.1",
-    "istanbul": "~0.2.7"
+    "connect": "~3.3.5",
+    "body-parser": "~1.12.4",
+    "istanbul": "~0.3.14"
   }
 }


### PR DESCRIPTION
Currently version `2.14.5` of connect is used and results in the following message:

``````
connect deprecated res.headerSent: use standard res.headersSent node_modules/grunt-protractor-coverage/node_modules/coverage-collector/node_modules/connect/lib/proto.js:127:22```

This patch will fixed that
``````
